### PR TITLE
fix(rma): find poetry path for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-POETRY=$(shell which poetry)
+ifeq ($(OS),Windows_NT)
+	POETRY=poetry
+else
+	POETRY=$(shell which poetry)
+endif
 
 test: install lint
 	$(POETRY) run pytest


### PR DESCRIPTION
Previously the which poetry shell variable could not be found on
windows, this fix to the make file ensures that it does.